### PR TITLE
Removed `-` from dev build Manifest `ResourceId` value

### DIFF
--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -2191,7 +2191,7 @@ int main (int argc, char* argv[]) {
 
           // internal
           if (flagDebugMode) {
-            suffix += "-dev";
+            suffix += "dev";
           }
 
           if (settings["meta_application_protocol"].size() == 0) {

--- a/src/desktop/main.cc
+++ b/src/desktop/main.cc
@@ -549,7 +549,7 @@ MAIN {
   }
 
   if (isDebugEnabled()) {
-    app.userConfig["build_name"] += "-dev";
+    app.userConfig["build_name"] += "dev";
   }
 
   app.userConfig["build_name"] += suffix;


### PR DESCRIPTION
## What
The hyphen in the ResourceId value in the Manifest would cause an error when packaging to .appx

## Why
Because it isn't allowed special characters.

## Notes
Now to get a packaged .appx:
- Open Powershell in the socket dir and run:
```bash
$env:NO_ANDROID=1; bin/install.ps1
```
- In the `socket.ini` file, I've set up my `[build]`, `[meta]` and `[win]` tags like this:
```ini
[build]
env = USER, TMPDIR, PWD
flags = -O3
headless = false
name = "substream"
output = "build"
copy = "dist"

[meta]
bundle_identifier = "com.substream"
application_protocol = "substream"
file_limit = 1024
lang = "en-us"
maintainer = "Playmint"
title = "substream"
version = 1.0.0
description = "Substream app"

[win]
logo = "app-win-512x512-2x.png"
icon = "src/assets/icons/app-win-512x512-2x.png"
icon_sizes = "512@1x"
; !! when the real certificate is added, the publisher value     !!
; !! must be updated to match the certificate publisher value    !!
publisher = "CN=Playmint"
; pfx = "certs/cert.pfx"
```

- `pfx = "certs/cert.pfx"` is to be replaced with a signed and verified Playmint certificate (otherwise the appx actually can't be installed)
- ⚠️ If there are any manifest errors, run: `"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x86\makeappx.exe"`
  - Example: `& "C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x86\MakeAppx.exe" pack /d [input_directory] /p [output_appx_file]`
- Refer to this PR: https://github.com/playmint/substream/pull/7 for changes to the substream repo